### PR TITLE
meld can be anywhere....

### DIFF
--- a/dif
+++ b/dif
@@ -714,15 +714,17 @@ if ( $opt{diff} ) {
 d '$gui';
 
 if ( $gui eq 'meld' ) {
-    my $meld;
     my $meld_161 = "/home/utils/meld-1.6.1/bin/meld";
     my $meld_186 = "/home/utils/meld-1.8.6/bin/meld";
+    my $meld=`which meld`;
+    chomp($meld);
     if ( -f $meld_186 ) {
         $meld = $meld_186;
     } elsif ( -f $meld_161 ) {
         $meld = $meld_161;
     } elsif ( -f '/usr/bin/meld' ) {
         $meld = '/usr/bin/meld';
+    } elsif ( -f $meld ) {  
     } else {
         say "WARNING:  meld not found.  Using gvimdiff instead" unless $opt{quiet};
         $meld = 'gvimdiff';


### PR DESCRIPTION
on my machine (mac OS X), my package installer put meld in /usr/local/bin.

I preserved the existing hard-coded checking for meld, and added in looking to see if meld is in the path anywhere. Line 727 says that if the result of 'which meld' is indeed a file that exists, do nothing (and therefore use that path).